### PR TITLE
Fix scoring bugs, verify DNS apply, harden installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          $results = Invoke-ScriptAnalyzer -Path ./DNS-Benchmark.ps1 -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Warning,Error -ReportSummary
+          $results = @()
+          $results += Invoke-ScriptAnalyzer -Path ./DNS-Benchmark.ps1 -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Warning,Error -ReportSummary
+          $results += Invoke-ScriptAnalyzer -Path ./install.ps1 -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Warning,Error -ReportSummary
           $results | Format-Table -AutoSize
           if ($results.Count -gt 0) {
             Write-Error "PSScriptAnalyzer found $($results.Count) issue(s)."

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Work plans (not committed)
+PLAN_TODAY.md
+
 # DNS Benchmark output files
 *.csv
 dns-backup_*.txt

--- a/DNS-Benchmark.ps1
+++ b/DNS-Benchmark.ps1
@@ -159,11 +159,11 @@ function Get-CompositeScore {
 
     $latencyRange = $MaxLatencyBound - $MinLatencyBound
     $speedScore = if ($latencyRange -gt 0) {
-        [math]::Round((1 - (($Result.AvgLatency - $MinLatencyBound) / $latencyRange)) * 100, 1)
+        [math]::Max(0, [math]::Round((1 - (($Result.AvgLatency - $MinLatencyBound) / $latencyRange)) * 100, 1))
     } else { 100 }
 
     $consistencyScore = if ($MaxJitterBound -gt 0) {
-        [math]::Round((1 - ($Result.Jitter / $MaxJitterBound)) * 100, 1)
+        [math]::Max(0, [math]::Round((1 - ($Result.Jitter / $MaxJitterBound)) * 100, 1))
     } else { 100 }
 
     [math]::Round(
@@ -246,11 +246,11 @@ function Set-OptimalDns {
     $null = Clear-DnsClientCache 2>$null
 
     $newDns = (Get-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -AddressFamily IPv4).ServerAddresses
-    $newDns[0] -eq $PrimaryDns
+    if (-not $newDns -or $newDns.Count -eq 0) { return $false }
+    ($newDns[0] -eq $PrimaryDns) -and ($newDns.Count -ge 2 -and $newDns[1] -eq $SecondaryDns)
 }
 
 # -- Banner ---------------------------------------------------------------------
-Clear-Host
 Write-Host ""
 Write-Host "   ____  _   _ ____  " -ForegroundColor Cyan
 Write-Host "  |  _ \| \ | / ___| " -ForegroundColor Cyan
@@ -403,7 +403,13 @@ Write-Info    "Features:         $($winner.Features)"
 # -- Export Report --------------------------------------------------------------
 if ($Report) {
     $reportPath = Join-Path $ScriptDir "DNS-Benchmark-Report_$(Get-Date -Format 'yyyy-MM-dd_HHmmss').csv"
-    $results | Select-Object Name, Primary, Secondary, AvgLatency, MedianLatency, MinLatency, MaxLatency, Jitter, Reliability, SecurityScore, CompositeScore, Features |
+    $rank = 0
+    $results | ForEach-Object {
+        $rank++
+        $_ | Add-Member -NotePropertyName "Rank" -NotePropertyValue $rank -Force
+        $_ | Add-Member -NotePropertyName "Grade" -NotePropertyValue (Get-LetterGrade -Score $_.CompositeScore) -Force
+        $_
+    } | Select-Object Rank, Name, Primary, Secondary, AvgLatency, MedianLatency, MinLatency, MaxLatency, Jitter, Reliability, SecurityScore, CompositeScore, Grade, Features |
         Export-Csv -Path $reportPath -NoTypeInformation
     Write-Host ""
     Write-Success "Report saved to: $reportPath"

--- a/install.ps1
+++ b/install.ps1
@@ -17,6 +17,7 @@ if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
 
 # ── Running as Admin from here ────────────────────────────────────────────────
 Set-ExecutionPolicy Bypass -Scope Process -Force
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $ErrorActionPreference = "Stop"
 $installDir = Join-Path $env:USERPROFILE "DNS-Benchmark"
 $scriptPath = Join-Path $installDir "DNS-Benchmark.ps1"

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     One-click installer & runner for DNS Benchmark & Optimizer.
     Downloads the latest version, self-elevates to admin, and runs the benchmark.
@@ -68,7 +68,6 @@ Write-Host ""
 # Pre-set directory variables so the script can find a valid path for backups/reports.
 # When run via ScriptBlock, $PSScriptRoot is empty — this fixes that.
 $ScriptDir = $installDir
-$PSScriptRoot = $installDir
 
 # Run directly from the in-memory string as a ScriptBlock.
 # This bypasses execution policy entirely — no .ps1 file is "loaded".

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -147,6 +147,28 @@ Describe "Get-CompositeScore" {
             $score | Should -Be 92.5
         }
 
+        It "Should clamp to zero when jitter exceeds MaxJitterBound" {
+            $result = [PSCustomObject]@{
+                AvgLatency    = 10.0
+                Jitter        = 80.0
+                Reliability   = 100.0
+                SecurityScore = 90
+            }
+            $score = Get-CompositeScore -Result $result -MaxLatencyBound 100 -MinLatencyBound 10 -MaxJitterBound 50
+            $score | Should -BeGreaterOrEqual 0
+        }
+
+        It "Should never return a negative score" {
+            $result = [PSCustomObject]@{
+                AvgLatency    = 200.0
+                Jitter        = 150.0
+                Reliability   = 50.0
+                SecurityScore = 30
+            }
+            $score = Get-CompositeScore -Result $result -MaxLatencyBound 100 -MinLatencyBound 10 -MaxJitterBound 50
+            $score | Should -BeGreaterOrEqual 0
+        }
+
         It "Should handle zero jitter bound" {
             $result = [PSCustomObject]@{
                 AvgLatency    = 20.0


### PR DESCRIPTION
## Summary

- **fix: prevent crash on empty DNS array** — `Set-OptimalDns` now guards against empty `ServerAddresses` instead of blindly indexing `[0]` (closes #4)
- **fix: verify both primary and secondary DNS** — verification after applying DNS now checks both addresses, not just the primary (closes #3)
- **fix: clamp negative composite scores to zero** — `speedScore` and `consistencyScore` can no longer go negative when jitter or latency exceeds bounds (closes #5)
- **fix: remove Clear-Host** — stops destroying terminal scrollback history on startup (closes #13)
- **fix: enforce TLS 1.2 in install.ps1** — prevents download failures on systems defaulting to older TLS versions (closes #1)
- **feat: add Rank and Grade columns to CSV report** — exported reports now include ranking position and letter grade (closes #10)
- **chore: lint install.ps1 in CI** — PSScriptAnalyzer now runs against both scripts (closes #15)
- **test: add coverage for negative score clamping** — two new Pester tests verify scores stay >= 0

## Test plan

- [ ] Pester tests pass in CI (includes new clamping tests)
- [ ] PSScriptAnalyzer passes for both scripts
- [ ] Manual: run with `-Report -SkipApply` and verify CSV has Rank/Grade columns
- [ ] Manual: run `-Restore` when already on DHCP to confirm no crash