### PR TITLE
fix: Set-OptimalDns error contract and JSON backup extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ PLAN_TODAY.md
 
 # DNS Benchmark output files
 *.csv
-dns-backup_*.txt
+dns-backup_*.json
 
 # Test results
 test-results.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to DNS Benchmark & Optimizer are documented here.
 
+## [Unreleased]
+
+### Fixed
+- `Set-OptimalDns` now returns `$false` on error instead of throwing, matching the documented boolean contract. Both the DNS apply and verify calls are wrapped with `-ErrorAction Stop` and try/catch (#20).
+- DNS backup files now use a `.json` extension instead of `.txt` so their contents match the name at a glance (#21). `.gitignore` updated to match.
+
+### Added
+- Pester coverage for `Set-OptimalDns` (success plus two failure paths) and the backup file extension.
+
 ## [1.1.0] — 2026-04-11
 
 ### Added

--- a/DNS-Benchmark.ps1
+++ b/DNS-Benchmark.ps1
@@ -242,10 +242,18 @@ function Set-OptimalDns {
         [string]$SecondaryDns
     )
 
-    Set-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -ServerAddresses @($PrimaryDns, $SecondaryDns)
+    try {
+        Set-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -ServerAddresses @($PrimaryDns, $SecondaryDns) -ErrorAction Stop
+    } catch {
+        return $false
+    }
     $null = Clear-DnsClientCache 2>$null
 
-    $newDns = (Get-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -AddressFamily IPv4).ServerAddresses
+    try {
+        $newDns = (Get-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -AddressFamily IPv4 -ErrorAction Stop).ServerAddresses
+    } catch {
+        return $false
+    }
     if (-not $newDns -or $newDns.Count -eq 0) { return $false }
     ($newDns[0] -eq $PrimaryDns) -and ($newDns.Count -ge 2 -and $newDns[1] -eq $SecondaryDns)
 }

--- a/DNS-Benchmark.ps1
+++ b/DNS-Benchmark.ps1
@@ -217,7 +217,7 @@ function Backup-DnsSettings {
 
     if (-not (Test-Path $BackupDir)) { New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null }
 
-    $backupPath = Join-Path $BackupDir "dns-backup_$(Get-Date -Format 'yyyy-MM-dd_HHmmss').txt"
+    $backupPath = Join-Path $BackupDir "dns-backup_$(Get-Date -Format 'yyyy-MM-dd_HHmmss').json"
     @{
         Adapter      = $AdapterName
         InterfaceIdx = $InterfaceIndex

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -369,6 +369,47 @@ Describe "Backup-DnsSettings" {
         $path = Backup-DnsSettings -BackupDir $newDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("1.1.1.1")
         Test-Path $path | Should -BeTrue
     }
+
+    It "Should use a .json extension for the backup file" {
+        $path = Backup-DnsSettings -BackupDir $testDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("1.1.1.1")
+        $path | Should -Match "dns-backup_.+\.json$"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Set-OptimalDns
+# ---------------------------------------------------------------------------
+Describe "Set-OptimalDns" {
+    It "Should return `$false when Set-DnsClientServerAddress throws" {
+        Mock Set-DnsClientServerAddress { throw "invalid interface" }
+        Mock Clear-DnsClientCache { }
+        Mock Get-DnsClientServerAddress {
+            [PSCustomObject]@{ ServerAddresses = @("1.1.1.1", "1.0.0.1") }
+        }
+
+        $result = Set-OptimalDns -InterfaceIndex 999 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1"
+        $result | Should -Be $false
+    }
+
+    It "Should return `$false when Get-DnsClientServerAddress throws" {
+        Mock Set-DnsClientServerAddress { }
+        Mock Clear-DnsClientCache { }
+        Mock Get-DnsClientServerAddress { throw "adapter gone" }
+
+        $result = Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1"
+        $result | Should -Be $false
+    }
+
+    It "Should return `$true when both DNS servers are applied correctly" {
+        Mock Set-DnsClientServerAddress { }
+        Mock Clear-DnsClientCache { }
+        Mock Get-DnsClientServerAddress {
+            [PSCustomObject]@{ ServerAddresses = @("1.1.1.1", "1.0.0.1") }
+        }
+
+        $result = Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1"
+        $result | Should -Be $true
+    }
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two small audit fixes plus tests.

## Changes
- `Set-OptimalDns` returns `$false` on failure instead of throwing. Both the apply and verify calls are now wrapped with `-ErrorAction Stop` + try/catch so an invalid interface or missing adapter produces the documented boolean, not an exception. (#20)
- DNS backup files are written with a `.json` extension so the name matches the JSON payload. `.gitignore` pattern updated to match. (#21)
- Pester: 3 new tests for `Set-OptimalDns` (success + both failure paths) and 1 asserting the `.json` extension. Full suite 41 passing locally.
- CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `Invoke-Pester ./tests` locally: 41/41 pass
- [ ] CI (PSScriptAnalyzer + Pester on Windows) green on the PR

## Out of scope
- #19 (TOCTOU in install.ps1) needs a real rework of the download/elevate flow; filed for a later day.