### PR TITLE
fix: progress padding, ScriptDir fallback, restore DHCP probe, query timeout, backup retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ All notable changes to DNS Benchmark & Optimizer are documented here.
 ### Fixed
 - `Set-OptimalDns` now returns `$false` on error instead of throwing, matching the documented boolean contract. Both the DNS apply and verify calls are wrapped with `-ErrorAction Stop` and try/catch (#20).
 - DNS backup files now use a `.json` extension instead of `.txt` so their contents match the name at a glance (#21). `.gitignore` updated to match.
+- `Resolve-DnsName` calls in the benchmark loop now use `-QuickTimeout`, so an unresponsive resolver no longer stalls the whole run for minutes (#6).
+- `$ScriptDir` resolution now prefers `$PSScriptRoot` when the script is run as a real `.ps1` file, then falls back to the caller-supplied `$ScriptDir`, then to the user-profile default. Backups and reports now land next to the script when run standalone (#17).
+- `-Restore` mode probes `Win32_NetworkAdapterConfiguration.DNSServerSearchOrder` first and reports "already using DHCP" instead of pretending to restore a setting that was never overridden (#16).
+- Progress bar lines are padded to a fixed width derived from the longest server name, so the previous server name no longer leaks through when shorter names follow (#11).
 
 ### Added
-- Pester coverage for `Set-OptimalDns` (success plus two failure paths) and the backup file extension.
+- `-MaxBackups` parameter on `Backup-DnsSettings` (default 10) prunes older `dns-backup_*.json` files after each new write so they no longer accumulate forever (#7).
+- Pester coverage for `Set-OptimalDns` (success plus two failure paths), the backup file extension, the new retention behavior, and `Test-StaticDnsConfigured`.
 
 ## [1.1.0] — 2026-04-11
 

--- a/DNS-Benchmark.ps1
+++ b/DNS-Benchmark.ps1
@@ -41,8 +41,13 @@ if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     exit 1
 }
 
-# -- Script directory (fallback for when run via ScriptBlock/iex where $ScriptDir is empty)
-$ScriptDir = if ($ScriptDir) { $ScriptDir } else { Join-Path $env:USERPROFILE "DNS-Benchmark" }
+# -- Script directory ----------------------------------------------------------
+# Order: $PSScriptRoot (set when run as a real .ps1 file), then a caller-supplied
+# $ScriptDir (set by install.ps1 before invoking via ScriptBlock), then a default
+# user-profile path for ad-hoc `iex` runs where neither is available.
+$ScriptDir = if ($PSScriptRoot) { $PSScriptRoot }
+             elseif ($ScriptDir) { $ScriptDir }
+             else { Join-Path $env:USERPROFILE "DNS-Benchmark" }
 if (-not (Test-Path $ScriptDir)) { New-Item -ItemType Directory -Path $ScriptDir -Force | Out-Null }
 
 # -- Color helpers --------------------------------------------------------------
@@ -86,7 +91,9 @@ function Get-DnsServerResults {
         for ($i = 0; $i -lt $QueryCount; $i++) {
             try {
                 $sw = [System.Diagnostics.Stopwatch]::StartNew()
-                $null = Resolve-DnsName -Name $domain -Server $DnsServer.Primary -DnsOnly -Type A -ErrorAction Stop
+                # -QuickTimeout shortens the per-query timeout so a single unresponsive
+                # server cannot stall the whole benchmark for minutes (#6).
+                $null = Resolve-DnsName -Name $domain -Server $DnsServer.Primary -DnsOnly -Type A -QuickTimeout -ErrorAction Stop
                 $sw.Stop()
                 $latencies += $sw.Elapsed.TotalMilliseconds
             }
@@ -201,7 +208,8 @@ function Get-LetterGrade {
 function Backup-DnsSettings {
     <#
     .SYNOPSIS
-        Saves current DNS settings to a timestamped JSON backup file.
+        Saves current DNS settings to a timestamped JSON backup file and prunes
+        older backups beyond -MaxBackups so they do not accumulate forever (#7).
     #>
     param(
         [Parameter(Mandatory)]
@@ -212,7 +220,9 @@ function Backup-DnsSettings {
         [int]$InterfaceIndex,
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
-        [string[]]$CurrentDns
+        [string[]]$CurrentDns,
+        [ValidateRange(1, 1000)]
+        [int]$MaxBackups = 10
     )
 
     if (-not (Test-Path $BackupDir)) { New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null }
@@ -225,7 +235,37 @@ function Backup-DnsSettings {
         Timestamp    = (Get-Date).ToString("o")
     } | ConvertTo-Json | Out-File -FilePath $backupPath -Encoding UTF8
 
+    $existing = @(Get-ChildItem -Path $BackupDir -Filter "dns-backup_*.json" -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending)
+    if ($existing.Count -gt $MaxBackups) {
+        $existing | Select-Object -Skip $MaxBackups | Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+
     $backupPath
+}
+
+function Test-StaticDnsConfigured {
+    <#
+    .SYNOPSIS
+        Returns $true when the adapter has a static DNS server list configured,
+        $false when the adapter is using DHCP-supplied DNS only.
+    .DESCRIPTION
+        Win32_NetworkAdapterConfiguration.DNSServerSearchOrder reflects the static
+        override list. It is empty/null when the adapter is using DHCP-supplied DNS.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [int]$InterfaceIndex
+    )
+
+    try {
+        $cfg = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "InterfaceIndex=$InterfaceIndex" -ErrorAction Stop
+    } catch {
+        return $true
+    }
+    if (-not $cfg) { return $true }
+    $static = $cfg.DNSServerSearchOrder
+    [bool]($static -and $static.Count -gt 0)
 }
 
 function Set-OptimalDns {
@@ -317,6 +357,12 @@ if ($Restore) {
     }
 
     Write-Status "Adapter: $($adapter.Name)"
+
+    if (-not (Test-StaticDnsConfigured -InterfaceIndex $adapter.InterfaceIndex)) {
+        Write-Info "'$($adapter.Name)' is already using DHCP-supplied DNS. Nothing to restore."
+        exit 0
+    }
+
     Set-DnsClientServerAddress -InterfaceIndex $adapter.InterfaceIndex -ResetServerAddresses
     Write-Success "DNS restored to automatic (DHCP) on '$($adapter.Name)'"
     Write-Info "You may need to run: ipconfig /flushdns"
@@ -344,17 +390,21 @@ Write-Host ""
 
 $results = @()
 $serverIndex = 0
+$maxNameLen = ($DnsServers | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum
+$progressWidth = 32 + $maxNameLen
 
 foreach ($dns in $DnsServers) {
     $serverIndex++
     $pct = [math]::Floor(($serverIndex / $DnsServers.Count) * 100)
     $bar = "#" * [math]::Floor($pct / 5) + "-" * (20 - [math]::Floor($pct / 5))
-    Write-Host "`r  [$bar] $pct% - Testing $($dns.Name)...                    " -NoNewline -ForegroundColor White
+    $line = "  [$bar] $pct% - Testing $($dns.Name)..."
+    Write-Host "`r$($line.PadRight($progressWidth))" -NoNewline -ForegroundColor White
 
     $results += Get-DnsServerResults -DnsServer $dns -Domains $TestDomains -QueryCount $TestCount
 }
 
-Write-Host "`r  [####################] 100% - Done!                              " -ForegroundColor Green
+$doneLine = "  [####################] 100% - Done!"
+Write-Host "`r$($doneLine.PadRight($progressWidth))" -ForegroundColor Green
 Write-Host ""
 
 # -- Composite Scoring ----------------------------------------------------------

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -374,6 +374,78 @@ Describe "Backup-DnsSettings" {
         $path = Backup-DnsSettings -BackupDir $testDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("1.1.1.1")
         $path | Should -Match "dns-backup_.+\.json$"
     }
+
+    Context "Backup retention (#7)" {
+        It "Should prune older backups beyond -MaxBackups" {
+            $retentionDir = Join-Path $env:TEMP "pester-dns-retention-$(Get-Random)"
+            New-Item -Path $retentionDir -ItemType Directory -Force | Out-Null
+
+            try {
+                # Seed with 8 stale backup files so we can confirm pruning order.
+                for ($i = 0; $i -lt 8; $i++) {
+                    $stale = Join-Path $retentionDir ("dns-backup_2025-01-{0:D2}_000000.json" -f ($i + 1))
+                    "{}" | Out-File -FilePath $stale -Encoding UTF8
+                    # Backdate so retention orders by LastWriteTime deterministically.
+                    (Get-Item $stale).LastWriteTime = (Get-Date).AddDays(-30 + $i)
+                }
+
+                $newPath = Backup-DnsSettings -BackupDir $retentionDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("1.1.1.1") -MaxBackups 5
+                $remaining = @(Get-ChildItem $retentionDir -Filter "dns-backup_*.json")
+
+                $remaining.Count | Should -Be 5
+                $remaining.FullName | Should -Contain $newPath
+            } finally {
+                Remove-Item $retentionDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "Should keep all backups when count is at or below -MaxBackups" {
+            $smallDir = Join-Path $env:TEMP "pester-dns-retention-small-$(Get-Random)"
+            New-Item -Path $smallDir -ItemType Directory -Force | Out-Null
+
+            try {
+                $p1 = Backup-DnsSettings -BackupDir $smallDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("1.1.1.1") -MaxBackups 10
+                Start-Sleep -Milliseconds 1100  # ensure distinct timestamp filename
+                $p2 = Backup-DnsSettings -BackupDir $smallDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("1.1.1.1") -MaxBackups 10
+
+                Test-Path $p1 | Should -BeTrue
+                Test-Path $p2 | Should -BeTrue
+            } finally {
+                Remove-Item $smallDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test-StaticDnsConfigured (#16 - restore mode DHCP detection)
+# ---------------------------------------------------------------------------
+Describe "Test-StaticDnsConfigured" {
+    It "Should return `$false when adapter has no static DNS list (DHCP-only)" {
+        Mock Get-CimInstance {
+            [PSCustomObject]@{ DNSServerSearchOrder = @() }
+        }
+        Test-StaticDnsConfigured -InterfaceIndex 5 | Should -Be $false
+    }
+
+    It "Should return `$false when DNSServerSearchOrder is `$null" {
+        Mock Get-CimInstance {
+            [PSCustomObject]@{ DNSServerSearchOrder = $null }
+        }
+        Test-StaticDnsConfigured -InterfaceIndex 5 | Should -Be $false
+    }
+
+    It "Should return `$true when adapter has a static DNS list" {
+        Mock Get-CimInstance {
+            [PSCustomObject]@{ DNSServerSearchOrder = @("1.1.1.1", "1.0.0.1") }
+        }
+        Test-StaticDnsConfigured -InterfaceIndex 5 | Should -Be $true
+    }
+
+    It "Should fail-safe to `$true when CIM query throws (caller still resets)" {
+        Mock Get-CimInstance { throw "WMI unavailable" }
+        Test-StaticDnsConfigured -InterfaceIndex 5 | Should -Be $true
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -393,7 +393,9 @@ Describe "Backup-DnsSettings" {
                 $remaining = @(Get-ChildItem $retentionDir -Filter "dns-backup_*.json")
 
                 $remaining.Count | Should -Be 5
-                $remaining.FullName | Should -Contain $newPath
+                # Compare leaf names so 8.3 short paths (e.g. RUNNER~1) vs long paths
+                # don't break the assertion across environments.
+                $remaining.Name | Should -Contain (Split-Path $newPath -Leaf)
             } finally {
                 Remove-Item $retentionDir -Recurse -Force -ErrorAction SilentlyContinue
             }


### PR DESCRIPTION
Single-day batch of small bug fixes from the open issue backlog. All changes covered by the existing Pester suite (now 47 tests, was 41) and PSScriptAnalyzer is clean against the project settings.

## Changes

- **Pad progress bar to a fixed width** so long server names no longer leak through to the next iteration when a shorter name follows. Closes #11.
- **Prefer `$PSScriptRoot` for `$ScriptDir`** when the script is run as a real `.ps1` file. Falls back to the caller-supplied `$ScriptDir` (set by `install.ps1` in the ScriptBlock path), then to the user-profile default for ad-hoc `iex` runs. Backups and reports now land next to the script when run standalone. Closes #17.
- **`-Restore` mode now probes `Win32_NetworkAdapterConfiguration.DNSServerSearchOrder`** before calling `Set-DnsClientServerAddress -ResetServerAddresses`. If no static DNS list is configured, it reports "already using DHCP" and exits, instead of pretending to restore a setting that was never overridden. Closes #16.
- **Add `-QuickTimeout` to `Resolve-DnsName`** in `Get-DnsServerResults` so a single unresponsive resolver no longer stalls the whole benchmark for minutes. Closes #6.
- **Add `-MaxBackups` (default 10) to `Backup-DnsSettings`**. Older `dns-backup_*.json` files are pruned by `LastWriteTime` after each new write so they no longer accumulate forever. Closes #7.

## Tests / lint

- `Invoke-Pester ./tests` — 47 passed, 0 failed.
- `Invoke-ScriptAnalyzer` against project settings on `DNS-Benchmark.ps1` and `install.ps1` — no warnings or errors.

## Out of scope

- #19, #9, #2 (install.ps1 TOCTOU and integrity verification) — deserve a dedicated security PR with a proper signed-content delivery rework.
- #14 (pre-flight connectivity check), #12 (parallel benchmark), #8 (IPv6 DNS support) — larger flow / data-model changes, separate PRs.