### PR TITLE
Harden the installer download path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ Thanks for your interest in contributing! Here's how to get started.
 - **No build step** — Edit the `.ps1` file and run it directly.
 - **Admin required** — The script changes DNS settings via `Set-DnsClientServerAddress`, which requires elevation. Use `-SkipApply` for safe benchmarking during development.
 - **PowerShell 5.1+** — Must work on the version pre-installed with Windows 10/11. Avoid PS 7-only syntax.
+- **Refresh the checksum after editing the benchmark** — `install.ps1` verifies `DNS-Benchmark.ps1` against the hash in `checksums.txt`. If you change the benchmark script, regenerate it or the installer (and the test suite) will reject the mismatch:
+  ```powershell
+  $c = [System.IO.File]::ReadAllText("DNS-Benchmark.ps1") -replace "`r`n","`n" -replace "`r","`n"
+  $h = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($c))).Replace("-","").ToLower()
+  Set-Content checksums.txt "$h  DNS-Benchmark.ps1" -NoNewline -Encoding utf8
+  ```
 
 ## Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,24 @@ All 17 tested DNS servers are well-known, publicly documented resolvers (Cloudfl
 
 The full list with IPs and security features is visible in the source code and README.
 
+## Installer Integrity
+
+The one-click installer (`install.ps1`) downloads `DNS-Benchmark.ps1` from this
+repository and runs it. Two safeguards protect that step:
+
+- **Single download for elevation.** When the installer needs Administrator
+  rights, it hands the already-loaded script to the elevated process through a
+  local temp file instead of fetching itself a second time. That removes the
+  gap where two separate downloads could return different code.
+- **Checksum verification.** Before running the benchmark script, the installer
+  downloads `checksums.txt` and compares the SHA-256 of the download against the
+  published hash. A mismatch stops the install.
+
+This guards against a corrupted or tampered transfer. It is not a defense
+against a full source compromise, because the checksum is fetched from the same
+repository as the script. For a stronger guarantee, review the source before
+running, or run `DNS-Benchmark.ps1` directly instead of the installer.
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability, please report it responsibly:

--- a/checksums.txt
+++ b/checksums.txt
@@ -1,0 +1,1 @@
+b713c65ec03c0a98957d50dff98f1f5c0c6589022bb4749e55ec36557fdabac9  DNS-Benchmark.ps1

--- a/install.ps1
+++ b/install.ps1
@@ -8,10 +8,20 @@
 if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Host "  Requesting Administrator privileges..." -ForegroundColor Yellow
 
-    $scriptUrl = "https://raw.githubusercontent.com/TiltedLunar123/DNS-Benchmark/master/install.ps1"
-    $elevatedCmd = "Set-ExecutionPolicy Bypass -Scope Process -Force; irm '$scriptUrl' | iex"
+    # Hand the elevated process the exact script we are already running rather
+    # than fetching install.ps1 a second time. A second download opens a window
+    # where someone on the network path could serve different code to the admin
+    # run than the user originally invoked.
+    $selfSource = if ($PSCommandPath) {
+        [System.IO.File]::ReadAllText($PSCommandPath)
+    } else {
+        $MyInvocation.MyCommand.Definition
+    }
 
-    Start-Process powershell -Verb RunAs -ArgumentList "-NoExit", "-ExecutionPolicy", "Bypass", "-Command", $elevatedCmd
+    $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) ("dns-benchmark-install-{0}.ps1" -f ([guid]::NewGuid().ToString('N')))
+    [System.IO.File]::WriteAllText($tempScript, $selfSource, [System.Text.Encoding]::UTF8)
+
+    Start-Process powershell -Verb RunAs -ArgumentList "-NoExit", "-ExecutionPolicy", "Bypass", "-File", $tempScript
     exit
 }
 
@@ -22,6 +32,20 @@ $ErrorActionPreference = "Stop"
 $installDir = Join-Path $env:USERPROFILE "DNS-Benchmark"
 $scriptPath = Join-Path $installDir "DNS-Benchmark.ps1"
 $repoBase = "https://raw.githubusercontent.com/TiltedLunar123/DNS-Benchmark/master"
+
+# SHA-256 over the script content with line endings normalized to LF, so the
+# result does not change when git checks the file out as CRLF on Windows.
+function Get-NormalizedScriptHash {
+    param([Parameter(Mandatory)][string] $Content)
+    $normalized = $Content -replace "`r`n", "`n" -replace "`r", "`n"
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalized)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return ([System.BitConverter]::ToString($sha.ComputeHash($bytes)) -replace '-', '').ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
 
 Write-Host ""
 Write-Host "  ========================================" -ForegroundColor Cyan
@@ -56,6 +80,49 @@ if (-not $scriptContent -or $scriptContent.Length -lt 500) {
     Read-Host "  Press Enter to exit"
     exit 1
 }
+
+# Verify the download against the published checksum before running it.
+# This catches a corrupted or tampered transfer. It does not defend against a
+# full source compromise, since the checksum is fetched from the same repo.
+Write-Host "  [*] Verifying integrity..." -ForegroundColor Yellow
+try {
+    $cacheBust = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $checksumFile = (New-Object System.Net.WebClient).DownloadString("$repoBase/checksums.txt?cb=$cacheBust")
+}
+catch {
+    Write-Host "  [-] Could not download checksums.txt: $_" -ForegroundColor Red
+    Write-Host "  [i] Refusing to run unverified code." -ForegroundColor Gray
+    Write-Host ""
+    Read-Host "  Press Enter to exit"
+    exit 1
+}
+
+$expectedHash = $null
+foreach ($line in ($checksumFile -split "`n")) {
+    if ($line -match '^\s*([0-9a-fA-F]{64})\s+\*?DNS-Benchmark\.ps1\s*$') {
+        $expectedHash = $Matches[1].ToLowerInvariant()
+        break
+    }
+}
+
+if (-not $expectedHash) {
+    Write-Host "  [-] No DNS-Benchmark.ps1 entry found in checksums.txt." -ForegroundColor Red
+    Write-Host ""
+    Read-Host "  Press Enter to exit"
+    exit 1
+}
+
+$actualHash = Get-NormalizedScriptHash -Content $scriptContent
+if ($actualHash -ne $expectedHash) {
+    Write-Host "  [-] Integrity check FAILED. The download does not match the published hash." -ForegroundColor Red
+    Write-Host "      expected: $expectedHash" -ForegroundColor Gray
+    Write-Host "      actual:   $actualHash" -ForegroundColor Gray
+    Write-Host "  [i] Not running it. Try again, and report this if it keeps happening." -ForegroundColor Gray
+    Write-Host ""
+    Read-Host "  Press Enter to exit"
+    exit 1
+}
+Write-Host "  [+] Integrity verified (sha256: $($actualHash.Substring(0,16))...)" -ForegroundColor Green
 
 # Save to disk for future manual use
 [System.IO.File]::WriteAllText($scriptPath, $scriptContent, [System.Text.Encoding]::UTF8)

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -499,3 +499,54 @@ Describe "Script Parameter Validation" {
         $validateRange | Should -Not -BeNullOrEmpty
     }
 }
+
+# ---------------------------------------------------------------------------
+# Published checksum (#2)
+# ---------------------------------------------------------------------------
+# install.ps1 refuses to run DNS-Benchmark.ps1 unless its hash matches the one
+# in checksums.txt. If the benchmark script changes and the checksum is not
+# refreshed, every install would fail the integrity check. This test fails
+# first so the drift is caught here instead of in the wild.
+Describe "Published checksum" {
+    BeforeAll {
+        $repoRoot = Join-Path $PSScriptRoot ".."
+        $script:benchmarkPath = Join-Path $repoRoot "DNS-Benchmark.ps1"
+        $script:checksumPath = Join-Path $repoRoot "checksums.txt"
+
+        function Get-NormalizedScriptHash {
+            param([string] $Content)
+            $normalized = $Content -replace "`r`n", "`n" -replace "`r", "`n"
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalized)
+            $sha = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                return ([System.BitConverter]::ToString($sha.ComputeHash($bytes)) -replace '-', '').ToLowerInvariant()
+            } finally {
+                $sha.Dispose()
+            }
+        }
+    }
+
+    It "checksums.txt exists" {
+        Test-Path $script:checksumPath | Should -BeTrue
+    }
+
+    It "lists a SHA-256 entry for DNS-Benchmark.ps1" {
+        $content = Get-Content $script:checksumPath -Raw
+        $content | Should -Match '(?m)^\s*[0-9a-fA-F]{64}\s+\*?DNS-Benchmark\.ps1\s*$'
+    }
+
+    It "matches the current DNS-Benchmark.ps1 hash" {
+        $checksumContent = Get-Content $script:checksumPath -Raw
+        $expected = $null
+        foreach ($line in ($checksumContent -split "`n")) {
+            if ($line -match '^\s*([0-9a-fA-F]{64})\s+\*?DNS-Benchmark\.ps1\s*$') {
+                $expected = $Matches[1].ToLowerInvariant()
+                break
+            }
+        }
+        $expected | Should -Not -BeNullOrEmpty
+
+        $actual = Get-NormalizedScriptHash -Content (Get-Content $script:benchmarkPath -Raw)
+        $actual | Should -Be $expected -Because "checksums.txt is stale; regenerate it after editing DNS-Benchmark.ps1"
+    }
+}


### PR DESCRIPTION
## Summary

Three open issues all point at `install.ps1`, and they share a theme: the installer trusts the network more than it should. This tightens that up.

- **Single download during elevation (closes #9, closes #19).** The non-admin run used to re-fetch `install.ps1` so the elevated process could run it. That second download is a window where someone on the path could feed the admin run different code. It now writes the script already in memory to a temp file and runs that local copy.
- **Checksum verification (closes #2).** Before running the downloaded benchmark, the installer pulls `checksums.txt` and compares the SHA-256, stopping on a mismatch. The hash is normalized to LF so a CRLF checkout does not break the comparison.
- **Drift guard.** New Pester tests recompute the hash and compare it to `checksums.txt`, so a stale checksum fails CI instead of breaking installs in the wild.
- **Docs.** SECURITY.md describes the new behavior and the honest limit that it does not stop a full source compromise. CONTRIBUTING.md notes how to refresh the hash.

## Notes

The checksum is fetched from the same repo as the script, so it guards against a corrupted or tampered transfer, not a full source takeover. That tradeoff is spelled out in SECURITY.md.

## Test plan

- [x] `Invoke-Pester ./tests` green (50 passed, 0 failed)
- [x] `Invoke-ScriptAnalyzer` reports zero issues on both scripts
- [ ] Manual: run the one-liner on a non-admin prompt and confirm the elevated window runs without a second download
- [ ] Manual: corrupt `checksums.txt` locally and confirm the installer refuses to run