### PR TITLE
Stop benchmarking when the machine has no DNS connectivity (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to DNS Benchmark & Optimizer are documented here.
 - Progress bar lines are padded to a fixed width derived from the longest server name, so the previous server name no longer leaks through when shorter names follow (#11).
 
 ### Added
+- Pre-flight connectivity check before benchmarking. `Test-NetworkConnectivity` probes a small set of anchor resolvers (1.1.1.1, 8.8.8.8, 9.9.9.9) and the script now exits with a clear message when none answer, instead of ranking a table of uniformly-failed servers and offering to apply a "winner" that was never reached (#14).
 - `-MaxBackups` parameter on `Backup-DnsSettings` (default 10) prunes older `dns-backup_*.json` files after each new write so they no longer accumulate forever (#7).
-- Pester coverage for `Set-OptimalDns` (success plus two failure paths), the backup file extension, the new retention behavior, and `Test-StaticDnsConfigured`.
+- Pester coverage for `Set-OptimalDns` (success plus two failure paths), the backup file extension, the new retention behavior, `Test-StaticDnsConfigured`, and the new connectivity probe (online, offline, and partial-reachability cases).
 
 ## [1.1.0] — 2026-04-11
 

--- a/DNS-Benchmark.ps1
+++ b/DNS-Benchmark.ps1
@@ -298,6 +298,48 @@ function Set-OptimalDns {
     ($newDns[0] -eq $PrimaryDns) -and ($newDns.Count -ge 2 -and $newDns[1] -eq $SecondaryDns)
 }
 
+function Test-NetworkConnectivity {
+    <#
+    .SYNOPSIS
+        Pre-flight check that confirms DNS can actually leave this machine
+        before a full benchmark is attempted (#14).
+    .DESCRIPTION
+        With no network, every server in the table fails identically, the tool
+        still crowns a "winner" from those uniformly-broken results, and it then
+        offers to apply DNS that was never really reached. This probes a small
+        set of well-known anchor resolvers and reports whether at least one
+        answered, so the caller can bail out with a clear message instead.
+    .PARAMETER AnchorServers
+        IPv4 addresses of reliable public resolvers to probe.
+    .PARAMETER ProbeDomain
+        Domain to resolve during the probe.
+    #>
+    param(
+        [string[]]$AnchorServers = @("1.1.1.1", "8.8.8.8", "9.9.9.9"),
+        [string]$ProbeDomain = "google.com"
+    )
+
+    $reachable = @()
+    foreach ($server in $AnchorServers) {
+        try {
+            # -QuickTimeout keeps a fully offline probe from stalling on each
+            # anchor; one answer is enough to prove DNS egress works.
+            $null = Resolve-DnsName -Name $ProbeDomain -Server $server -DnsOnly -Type A -QuickTimeout -ErrorAction Stop
+            $reachable += $server
+        }
+        catch {
+            # A throw here is expected when offline; keep probing the rest.
+            Write-Verbose "Connectivity probe to $server failed: $_"
+        }
+    }
+
+    [PSCustomObject]@{
+        Online           = ($reachable.Count -gt 0)
+        ReachableServers = $reachable
+        ProbedServers    = $AnchorServers
+    }
+}
+
 # -- Banner ---------------------------------------------------------------------
 Write-Host ""
 Write-Host "   ____  _   _ ____  " -ForegroundColor Cyan
@@ -382,6 +424,18 @@ $currentDns = (Get-DnsClientServerAddress -InterfaceIndex $adapter.InterfaceInde
 Write-Success "Active adapter: $($adapter.Name) ($($adapter.InterfaceDescription))"
 Write-Info    "Current DNS:    $($currentDns -join ', ')"
 Write-Info    "Link speed:     $($adapter.LinkSpeed)"
+
+# -- Pre-flight connectivity check ---------------------------------------------
+# Bail out before the benchmark if DNS cannot leave the machine. Otherwise every
+# server fails the same way and the tool crowns a meaningless "winner" (#14).
+Write-Status "Checking DNS connectivity..."
+$connectivity = Test-NetworkConnectivity
+if (-not $connectivity.Online) {
+    Write-Err "No DNS connectivity. Probed $($connectivity.ProbedServers -join ', ') and none answered."
+    Write-Info "Check your network connection and try again."
+    exit 1
+}
+Write-Success "Connectivity OK (reached $($connectivity.ReachableServers -join ', '))"
 
 # -- Benchmark ------------------------------------------------------------------
 Write-Header "Benchmarking $($DnsServers.Count) DNS Servers"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Results are displayed with letter grades (A+ through F) and the top 3 are starre
 
 ## Safety Features
 
+- **Pre-flight connectivity check** - probes a few public resolvers before benchmarking, so an offline machine gets a clear message instead of a ranking built from failed queries
 - **Asks before applying** - won't change DNS without your confirmation
 - **Automatic backup** - saves your previous DNS settings to a timestamped file before changing
 - **Easy restore** - run with `-Restore` to go back to DHCP defaults

--- a/checksums.txt
+++ b/checksums.txt
@@ -1,1 +1,1 @@
-b713c65ec03c0a98957d50dff98f1f5c0c6589022bb4749e55ec36557fdabac9  DNS-Benchmark.ps1
+91b592833c3ec0aca919b366aab360d0db80db244d59fb9dcc4b95b6a6688e5f  DNS-Benchmark.ps1

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -487,6 +487,75 @@ Describe "Set-OptimalDns" {
 }
 
 # ---------------------------------------------------------------------------
+# Test-NetworkConnectivity (#14 - pre-flight connectivity check)
+# ---------------------------------------------------------------------------
+Describe "Test-NetworkConnectivity" {
+    Context "When at least one anchor answers" {
+        BeforeAll {
+            Mock Resolve-DnsName { }
+        }
+
+        It "Should report Online when every probe succeeds" {
+            $result = Test-NetworkConnectivity -AnchorServers @("1.1.1.1", "8.8.8.8")
+            $result.Online | Should -BeTrue
+        }
+
+        It "Should list every reachable server" {
+            $result = Test-NetworkConnectivity -AnchorServers @("1.1.1.1", "8.8.8.8")
+            $result.ReachableServers | Should -Contain "1.1.1.1"
+            $result.ReachableServers | Should -Contain "8.8.8.8"
+        }
+
+        It "Should echo back the servers it probed" {
+            $result = Test-NetworkConnectivity -AnchorServers @("9.9.9.9")
+            $result.ProbedServers | Should -Be @("9.9.9.9")
+        }
+    }
+
+    Context "When no anchor answers" {
+        BeforeAll {
+            Mock Resolve-DnsName { throw "no route to host" }
+        }
+
+        It "Should report offline" {
+            $result = Test-NetworkConnectivity -AnchorServers @("1.1.1.1", "8.8.8.8", "9.9.9.9")
+            $result.Online | Should -BeFalse
+        }
+
+        It "Should return an empty reachable list" {
+            $result = Test-NetworkConnectivity -AnchorServers @("1.1.1.1", "8.8.8.8")
+            $result.ReachableServers | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When only some anchors answer" {
+        BeforeAll {
+            Mock Resolve-DnsName { } -ParameterFilter { $Server -eq "8.8.8.8" }
+            Mock Resolve-DnsName { throw "timeout" } -ParameterFilter { $Server -ne "8.8.8.8" }
+        }
+
+        It "Should still report Online" {
+            $result = Test-NetworkConnectivity -AnchorServers @("1.1.1.1", "8.8.8.8", "9.9.9.9")
+            $result.Online | Should -BeTrue
+        }
+
+        It "Should list only the anchor that answered" {
+            $result = Test-NetworkConnectivity -AnchorServers @("1.1.1.1", "8.8.8.8", "9.9.9.9")
+            $result.ReachableServers | Should -Be @("8.8.8.8")
+        }
+    }
+
+    Context "Defaults" {
+        It "Should default to three public anchor resolvers" {
+            Mock Resolve-DnsName { }
+            $result = Test-NetworkConnectivity
+            $result.ProbedServers.Count | Should -Be 3
+            $result.ProbedServers | Should -Contain "1.1.1.1"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Parameter validation
 # ---------------------------------------------------------------------------
 Describe "Script Parameter Validation" {


### PR DESCRIPTION
Running the benchmark offline used to produce a table where every server failed identically. The tool still ranked them, crowned a "winner", and offered to apply DNS that was never actually reached. This adds a quick pre-flight probe so you get a clear "check your connection" message instead.

What changed:
- New `Test-NetworkConnectivity` function probes a few well-known anchor resolvers (1.1.1.1, 8.8.8.8, 9.9.9.9). One answer is enough to confirm DNS egress works; an offline probe uses `-QuickTimeout` so it doesn't stall on each anchor.
- Wired in right after adapter detection. If nothing answers, the script prints which servers it tried and exits instead of building a bogus ranking.
- Pester coverage for the online, offline, and partial-reachability cases.
- README safety-features list and the changelog Unreleased section both mention it.
- Refreshed `checksums.txt` so the installer's integrity check still matches the edited script.

Local checks: PSScriptAnalyzer clean, Pester 58/58 green.

closes #14

Follow-ups still open: parallel benchmarking (#12) and IPv6 support (#8).