### PR TITLE
Apply IPv6 DNS alongside IPv4 with an opt-in -IncludeIPv6 switch (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to DNS Benchmark & Optimizer are documented here.
 - Progress bar lines are padded to a fixed width derived from the longest server name, so the previous server name no longer leaks through when shorter names follow (#11).
 
 ### Added
+- Optional IPv6 DNS. A new `-IncludeIPv6` switch applies the winning resolver's IPv6 anycast addresses alongside IPv4, closing the gap where a dual-stack machine could keep resolving over the router's IPv6 DNS and bypass the resolver the benchmark picked (#8). Most providers in the table now carry their published IPv6 addresses; the apply only runs when the adapter has IPv6 bound and the winner has v6 on file, and `Set-OptimalDns` verifies the IPv6 family so a partial apply reports failure. The previous IPv6 servers are recorded in the backup. Off by default, so an IPv6 config is never changed unless asked for.
 - Pre-flight connectivity check before benchmarking. `Test-NetworkConnectivity` probes a small set of anchor resolvers (1.1.1.1, 8.8.8.8, 9.9.9.9) and the script now exits with a clear message when none answer, instead of ranking a table of uniformly-failed servers and offering to apply a "winner" that was never reached (#14).
 - `-MaxBackups` parameter on `Backup-DnsSettings` (default 10) prunes older `dns-backup_*.json` files after each new write so they no longer accumulate forever (#7).
-- Pester coverage for `Set-OptimalDns` (success plus two failure paths), the backup file extension, the new retention behavior, `Test-StaticDnsConfigured`, and the new connectivity probe (online, offline, and partial-reachability cases).
+- Pester coverage for `Set-OptimalDns` (success plus two failure paths, plus the IPv6 apply path), `Test-IPv6Available`, the IPv6 backup field, a parsed-from-source check that every IPv6 resolver entry is a real paired IPv6 literal, the backup file extension, the retention behavior, `Test-StaticDnsConfigured`, and the connectivity probe (online, offline, and partial-reachability cases).
 
 ## [1.1.0] — 2026-04-11
 

--- a/DNS-Benchmark.ps1
+++ b/DNS-Benchmark.ps1
@@ -18,10 +18,17 @@
 .PARAMETER Report
     Export results to a CSV file.
 
+.PARAMETER IncludeIPv6
+    Also apply the winning resolver's IPv6 DNS addresses alongside IPv4, when the
+    adapter has IPv6 bound and the resolver publishes IPv6. Off by default so an
+    IPv6 config is never changed unless asked for. Without it, a dual-stack box
+    can still resolve over whatever IPv6 DNS the router handed out.
+
 .EXAMPLE
     .\DNS-Benchmark.ps1
     .\DNS-Benchmark.ps1 -TestCount 10 -Report
     .\DNS-Benchmark.ps1 -SkipApply
+    .\DNS-Benchmark.ps1 -IncludeIPv6
     .\DNS-Benchmark.ps1 -Restore
 #>
 
@@ -31,7 +38,8 @@ param(
     [int]$TestCount = 5,
     [switch]$SkipApply,
     [switch]$Restore,
-    [switch]$Report
+    [switch]$Report,
+    [switch]$IncludeIPv6
 )
 
 # -- Admin check --------------------------------------------------------------------------
@@ -221,6 +229,8 @@ function Backup-DnsSettings {
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [string[]]$CurrentDns,
+        [AllowEmptyCollection()]
+        [string[]]$CurrentDnsV6 = @(),
         [ValidateRange(1, 1000)]
         [int]$MaxBackups = 10
     )
@@ -229,10 +239,11 @@ function Backup-DnsSettings {
 
     $backupPath = Join-Path $BackupDir "dns-backup_$(Get-Date -Format 'yyyy-MM-dd_HHmmss').json"
     @{
-        Adapter      = $AdapterName
-        InterfaceIdx = $InterfaceIndex
-        PreviousDNS  = $CurrentDns -join ","
-        Timestamp    = (Get-Date).ToString("o")
+        Adapter       = $AdapterName
+        InterfaceIdx  = $InterfaceIndex
+        PreviousDNS   = $CurrentDns -join ","
+        PreviousDNSv6 = $CurrentDnsV6 -join ","
+        Timestamp     = (Get-Date).ToString("o")
     } | ConvertTo-Json | Out-File -FilePath $backupPath -Encoding UTF8
 
     $existing = @(Get-ChildItem -Path $BackupDir -Filter "dns-backup_*.json" -File -ErrorAction SilentlyContinue |
@@ -272,6 +283,11 @@ function Set-OptimalDns {
     <#
     .SYNOPSIS
         Applies DNS servers to a network adapter and flushes the DNS cache.
+    .DESCRIPTION
+        Always sets the IPv4 pair. When both IPv6 addresses are supplied they are
+        sent in the same Set-DnsClientServerAddress call (Windows routes each
+        address to its own family) and the IPv6 family is verified too, so a
+        partial apply is reported as a failure (#8).
     #>
     param(
         [Parameter(Mandatory)]
@@ -279,11 +295,19 @@ function Set-OptimalDns {
         [Parameter(Mandatory)]
         [string]$PrimaryDns,
         [Parameter(Mandatory)]
-        [string]$SecondaryDns
+        [string]$SecondaryDns,
+        [string]$PrimaryDnsV6 = "",
+        [string]$SecondaryDnsV6 = ""
     )
 
+    $applyV6 = -not [string]::IsNullOrWhiteSpace($PrimaryDnsV6) -and
+               -not [string]::IsNullOrWhiteSpace($SecondaryDnsV6)
+
+    $addresses = @($PrimaryDns, $SecondaryDns)
+    if ($applyV6) { $addresses += @($PrimaryDnsV6, $SecondaryDnsV6) }
+
     try {
-        Set-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -ServerAddresses @($PrimaryDns, $SecondaryDns) -ErrorAction Stop
+        Set-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -ServerAddresses $addresses -ErrorAction Stop
     } catch {
         return $false
     }
@@ -295,7 +319,19 @@ function Set-OptimalDns {
         return $false
     }
     if (-not $newDns -or $newDns.Count -eq 0) { return $false }
-    ($newDns[0] -eq $PrimaryDns) -and ($newDns.Count -ge 2 -and $newDns[1] -eq $SecondaryDns)
+    $ipv4Ok = ($newDns[0] -eq $PrimaryDns) -and ($newDns.Count -ge 2 -and $newDns[1] -eq $SecondaryDns)
+
+    if (-not $applyV6) { return $ipv4Ok }
+
+    try {
+        $newDns6 = (Get-DnsClientServerAddress -InterfaceIndex $InterfaceIndex -AddressFamily IPv6 -ErrorAction Stop).ServerAddresses
+    } catch {
+        return $false
+    }
+    if (-not $newDns6 -or $newDns6.Count -eq 0) { return $false }
+    $ipv6Ok = ($newDns6[0] -eq $PrimaryDnsV6) -and ($newDns6.Count -ge 2 -and $newDns6[1] -eq $SecondaryDnsV6)
+
+    $ipv4Ok -and $ipv6Ok
 }
 
 function Test-NetworkConnectivity {
@@ -340,6 +376,29 @@ function Test-NetworkConnectivity {
     }
 }
 
+function Test-IPv6Available {
+    <#
+    .SYNOPSIS
+        Returns $true when the adapter has the IPv6 stack bound, $false otherwise.
+    .DESCRIPTION
+        Setting IPv6 DNS on an adapter whose IPv6 (ms_tcpip6) binding is disabled
+        throws. This checks the binding first so the caller can fall back to an
+        IPv4-only apply cleanly. Fail-safe to $false: if the binding cannot be
+        read, IPv6 is treated as unavailable and only IPv4 is applied (#8).
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$AdapterName
+    )
+
+    try {
+        $binding = Get-NetAdapterBinding -Name $AdapterName -ComponentID 'ms_tcpip6' -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    [bool]($binding -and $binding.Enabled)
+}
+
 # -- Banner ---------------------------------------------------------------------
 Write-Host ""
 Write-Host "   ____  _   _ ____  " -ForegroundColor Cyan
@@ -351,25 +410,28 @@ Write-Host "  Benchmark and Optimizer" -ForegroundColor White
 Write-Host ""
 
 # -- DNS Server Database --------------------------------------------------------
-# Each entry: Name, Primary IPv4, Secondary IPv4, Security Score (0-100)
+# Each entry: Name, Primary IPv4, Secondary IPv4, Security Score (0-100), Features,
+# and optional PrimaryV6/SecondaryV6 anycast addresses for providers that publish
+# them. IPv6 is only applied when -IncludeIPv6 is set (see Set-OptimalDns). Entries
+# without published, stable IPv6 anycast are intentionally left IPv4-only.
 # Security scoring based on: DNSSEC validation, no-logging policy, malware blocking,
 # DNS-over-HTTPS support, DNS-over-TLS support, open-source/audited
 $DnsServers = @(
-    @{ Name = "Cloudflare";              Primary = "1.1.1.1";       Secondary = "1.0.0.1";       SecurityScore = 92;  Features = "DNSSEC, DoH, DoT, no-log policy, audited privacy" }
-    @{ Name = "Cloudflare (Malware)";    Primary = "1.1.1.2";       Secondary = "1.0.0.2";       SecurityScore = 95;  Features = "DNSSEC, DoH, DoT, malware blocking, no-log" }
-    @{ Name = "Cloudflare (Family)";     Primary = "1.1.1.3";       Secondary = "1.0.0.3";       SecurityScore = 95;  Features = "DNSSEC, DoH, DoT, malware + adult blocking" }
-    @{ Name = "Google";                  Primary = "8.8.8.8";       Secondary = "8.8.4.4";       SecurityScore = 78;  Features = "DNSSEC, DoH, DoT, logs anonymized after 48h" }
-    @{ Name = "Quad9";                   Primary = "9.9.9.9";       Secondary = "149.112.112.112"; SecurityScore = 96; Features = "DNSSEC, DoH, DoT, threat blocking, non-profit, no-log" }
-    @{ Name = "Quad9 (Unfiltered)";      Primary = "9.9.9.10";      Secondary = "149.112.112.10"; SecurityScore = 88;  Features = "DNSSEC, DoH, DoT, no filtering, no-log" }
-    @{ Name = "OpenDNS";                 Primary = "208.67.222.222"; Secondary = "208.67.220.220"; SecurityScore = 80;  Features = "DNSSEC, DoH, phishing protection, Cisco-owned" }
+    @{ Name = "Cloudflare";              Primary = "1.1.1.1";       Secondary = "1.0.0.1";       PrimaryV6 = "2606:4700:4700::1111"; SecondaryV6 = "2606:4700:4700::1001"; SecurityScore = 92;  Features = "DNSSEC, DoH, DoT, no-log policy, audited privacy" }
+    @{ Name = "Cloudflare (Malware)";    Primary = "1.1.1.2";       Secondary = "1.0.0.2";       PrimaryV6 = "2606:4700:4700::1112"; SecondaryV6 = "2606:4700:4700::1002"; SecurityScore = 95;  Features = "DNSSEC, DoH, DoT, malware blocking, no-log" }
+    @{ Name = "Cloudflare (Family)";     Primary = "1.1.1.3";       Secondary = "1.0.0.3";       PrimaryV6 = "2606:4700:4700::1113"; SecondaryV6 = "2606:4700:4700::1003"; SecurityScore = 95;  Features = "DNSSEC, DoH, DoT, malware + adult blocking" }
+    @{ Name = "Google";                  Primary = "8.8.8.8";       Secondary = "8.8.4.4";       PrimaryV6 = "2001:4860:4860::8888"; SecondaryV6 = "2001:4860:4860::8844"; SecurityScore = 78;  Features = "DNSSEC, DoH, DoT, logs anonymized after 48h" }
+    @{ Name = "Quad9";                   Primary = "9.9.9.9";       Secondary = "149.112.112.112"; PrimaryV6 = "2620:fe::fe"; SecondaryV6 = "2620:fe::9"; SecurityScore = 96; Features = "DNSSEC, DoH, DoT, threat blocking, non-profit, no-log" }
+    @{ Name = "Quad9 (Unfiltered)";      Primary = "9.9.9.10";      Secondary = "149.112.112.10"; PrimaryV6 = "2620:fe::10"; SecondaryV6 = "2620:fe::fe:10"; SecurityScore = 88;  Features = "DNSSEC, DoH, DoT, no filtering, no-log" }
+    @{ Name = "OpenDNS";                 Primary = "208.67.222.222"; Secondary = "208.67.220.220"; PrimaryV6 = "2620:119:35::35"; SecondaryV6 = "2620:119:53::53"; SecurityScore = 80;  Features = "DNSSEC, DoH, phishing protection, Cisco-owned" }
     @{ Name = "OpenDNS (FamilyShield)";  Primary = "208.67.222.123"; Secondary = "208.67.220.123"; SecurityScore = 82; Features = "DNSSEC, DoH, family filter, phishing protection" }
-    @{ Name = "AdGuard";                 Primary = "94.140.14.14";  Secondary = "94.140.15.15";  SecurityScore = 90;  Features = "DNSSEC, DoH, DoT, ad/tracker/malware blocking" }
-    @{ Name = "AdGuard (Family)";        Primary = "94.140.14.15";  Secondary = "94.140.15.16";  SecurityScore = 91;  Features = "DNSSEC, DoH, DoT, family filter + ad blocking" }
+    @{ Name = "AdGuard";                 Primary = "94.140.14.14";  Secondary = "94.140.15.15";  PrimaryV6 = "2a10:50c0::ad1:ff"; SecondaryV6 = "2a10:50c0::ad2:ff"; SecurityScore = 90;  Features = "DNSSEC, DoH, DoT, ad/tracker/malware blocking" }
+    @{ Name = "AdGuard (Family)";        Primary = "94.140.14.15";  Secondary = "94.140.15.16";  PrimaryV6 = "2a10:50c0::bad1:ff"; SecondaryV6 = "2a10:50c0::bad2:ff"; SecurityScore = 91;  Features = "DNSSEC, DoH, DoT, family filter + ad blocking" }
     @{ Name = "Comodo Secure";           Primary = "8.26.56.26";    Secondary = "8.20.247.20";   SecurityScore = 72;  Features = "Malware blocking, phishing protection" }
-    @{ Name = "CleanBrowsing (Security)";Primary = "185.228.168.9"; Secondary = "185.228.169.9"; SecurityScore = 88;  Features = "DNSSEC, DoH, DoT, malware/phishing blocking" }
-    @{ Name = "CleanBrowsing (Family)";  Primary = "185.228.168.168"; Secondary = "185.228.169.168"; SecurityScore = 89; Features = "DNSSEC, DoH, DoT, family + security filter" }
-    @{ Name = "Mullvad";                 Primary = "194.242.2.2";   Secondary = "194.242.2.3";   SecurityScore = 94;  Features = "DNSSEC, DoH, DoT, no-log, privacy-focused VPN company" }
-    @{ Name = "Control D";              Primary = "76.76.2.0";     Secondary = "76.76.10.0";    SecurityScore = 86;  Features = "DNSSEC, DoH, DoT, customizable filtering" }
+    @{ Name = "CleanBrowsing (Security)";Primary = "185.228.168.9"; Secondary = "185.228.169.9"; PrimaryV6 = "2a0d:2a00:1::"; SecondaryV6 = "2a0d:2a00:2::"; SecurityScore = 88;  Features = "DNSSEC, DoH, DoT, malware/phishing blocking" }
+    @{ Name = "CleanBrowsing (Family)";  Primary = "185.228.168.168"; Secondary = "185.228.169.168"; PrimaryV6 = "2a0d:2a00:1::1"; SecondaryV6 = "2a0d:2a00:2::1"; SecurityScore = 89; Features = "DNSSEC, DoH, DoT, family + security filter" }
+    @{ Name = "Mullvad";                 Primary = "194.242.2.2";   Secondary = "194.242.2.3";   PrimaryV6 = "2a07:e340::2"; SecondaryV6 = "2a07:e340::3"; SecurityScore = 94;  Features = "DNSSEC, DoH, DoT, no-log, privacy-focused VPN company" }
+    @{ Name = "Control D";              Primary = "76.76.2.0";     Secondary = "76.76.10.0";    PrimaryV6 = "2606:1a40::"; SecondaryV6 = "2606:1a40:1::"; SecurityScore = 86;  Features = "DNSSEC, DoH, DoT, customizable filtering" }
     @{ Name = "Neustar UltraDNS";       Primary = "64.6.64.6";     Secondary = "64.6.65.6";     SecurityScore = 70;  Features = "DNSSEC, enterprise-grade reliability" }
     @{ Name = "Level3 / CenturyLink";   Primary = "4.2.2.1";       Secondary = "4.2.2.2";       SecurityScore = 55;  Features = "Basic DNS, no encryption, no filtering" }
 )
@@ -532,6 +594,24 @@ if (-not $SkipApply) {
     Write-Host ""
     Write-Header "Apply DNS Settings"
 
+    # Decide whether IPv6 is in play: the opt-in switch is set, the winning
+    # resolver publishes IPv6 anycast, and the adapter actually has IPv6 bound.
+    # Any of those missing and we apply IPv4 only, exactly as before (#8).
+    $winnerV6Primary   = if ($winner.PrimaryV6)   { [string]$winner.PrimaryV6 }   else { "" }
+    $winnerV6Secondary = if ($winner.SecondaryV6) { [string]$winner.SecondaryV6 } else { "" }
+    $applyV6 = $IncludeIPv6 -and
+               -not [string]::IsNullOrWhiteSpace($winnerV6Primary) -and
+               -not [string]::IsNullOrWhiteSpace($winnerV6Secondary) -and
+               (Test-IPv6Available -AdapterName $adapter.Name)
+
+    if ($IncludeIPv6 -and -not $applyV6) {
+        if ([string]::IsNullOrWhiteSpace($winnerV6Primary)) {
+            Write-Info "-IncludeIPv6 set, but $($winner.Name) has no IPv6 address on file. Applying IPv4 only."
+        } else {
+            Write-Info "-IncludeIPv6 set, but this adapter has no IPv6 bound. Applying IPv4 only."
+        }
+    }
+
     # Check if already using the winner
     if ($currentDns -and $currentDns[0] -eq $winner.Primary) {
         Write-Success "You're already using the best DNS ($($winner.Name)). No changes needed!"
@@ -541,19 +621,37 @@ if (-not $SkipApply) {
     Write-Status "This will change DNS on '$($adapter.Name)' to:"
     Write-Host "         Primary:   $($winner.Primary)" -ForegroundColor White
     Write-Host "         Secondary: $($winner.Secondary)" -ForegroundColor White
+    if ($applyV6) {
+        Write-Host "         IPv6 Pri:  $winnerV6Primary" -ForegroundColor White
+        Write-Host "         IPv6 Sec:  $winnerV6Secondary" -ForegroundColor White
+    }
     Write-Host ""
 
     $confirm = Read-Host "  Apply these settings? (Y/n)"
     if ($confirm -match "^[Yy]?$") {
         try {
-            $backupPath = Backup-DnsSettings -BackupDir $ScriptDir -AdapterName $adapter.Name -InterfaceIndex $adapter.InterfaceIndex -CurrentDns $currentDns
+            $currentDnsV6 = @()
+            if ($applyV6) {
+                try {
+                    $currentDnsV6 = @((Get-DnsClientServerAddress -InterfaceIndex $adapter.InterfaceIndex -AddressFamily IPv6 -ErrorAction Stop).ServerAddresses)
+                } catch {
+                    $currentDnsV6 = @()
+                }
+            }
+
+            $backupPath = Backup-DnsSettings -BackupDir $ScriptDir -AdapterName $adapter.Name -InterfaceIndex $adapter.InterfaceIndex -CurrentDns $currentDns -CurrentDnsV6 $currentDnsV6
             Write-Info "Backup saved: $backupPath"
 
-            $applied = Set-OptimalDns -InterfaceIndex $adapter.InterfaceIndex -PrimaryDns $winner.Primary -SecondaryDns $winner.Secondary
+            $applied = if ($applyV6) {
+                Set-OptimalDns -InterfaceIndex $adapter.InterfaceIndex -PrimaryDns $winner.Primary -SecondaryDns $winner.Secondary -PrimaryDnsV6 $winnerV6Primary -SecondaryDnsV6 $winnerV6Secondary
+            } else {
+                Set-OptimalDns -InterfaceIndex $adapter.InterfaceIndex -PrimaryDns $winner.Primary -SecondaryDns $winner.Secondary
+            }
 
             if ($applied) {
                 Write-Host ""
                 Write-Success "DNS changed to $($winner.Name) ($($winner.Primary), $($winner.Secondary))"
+                if ($applyV6) { Write-Success "IPv6 DNS set ($winnerV6Primary, $winnerV6Secondary)" }
                 Write-Success "DNS cache flushed"
                 Write-Info    "Previous DNS backed up to: $backupPath"
                 Write-Info    "To restore: .\DNS-Benchmark.ps1 -Restore"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The script will benchmark all DNS servers and ask before applying any changes.
 # Export results to CSV
 .\DNS-Benchmark.ps1 -Report
 
+# Also set the winner's IPv6 DNS (dual-stack networks)
+.\DNS-Benchmark.ps1 -IncludeIPv6
+
 # Combine flags
 .\DNS-Benchmark.ps1 -TestCount 10 -Report -SkipApply
 
@@ -95,6 +98,20 @@ The script will benchmark all DNS servers and ask before applying any changes.
 | `-SkipApply` | switch | false | Benchmark only, don't apply changes |
 | `-Restore` | switch | false | Reset DNS to DHCP/automatic |
 | `-Report` | switch | false | Export results to CSV |
+| `-IncludeIPv6` | switch | false | Also apply the winner's IPv6 DNS (see below) |
+
+## IPv6 (Dual-Stack Networks)
+
+By default the script only touches IPv4 DNS. On a dual-stack network that
+leaves a gap: the machine can still resolve over whatever IPv6 DNS the router
+handed out, quietly bypassing the resolver you just picked.
+
+Run with `-IncludeIPv6` to also set the winning provider's IPv6 addresses.
+It only does so when the adapter actually has IPv6 bound and the chosen
+resolver publishes IPv6 anycast (most in the list do; a few are IPv4-only and
+are applied as IPv4 only). The previous IPv6 servers are saved in the same
+backup, and `-Restore` clears both families. It stays off by default so an
+IPv6 configuration is never changed unless you ask for it.
 
 ## How Scoring Works
 

--- a/checksums.txt
+++ b/checksums.txt
@@ -1,1 +1,1 @@
-91b592833c3ec0aca919b366aab360d0db80db244d59fb9dcc4b95b6a6688e5f  DNS-Benchmark.ps1
+769eb3b99bb2cf9e3e74f40dc5d22ec91e852cfba300d0d0cc0cfe0d4774a351  DNS-Benchmark.ps1

--- a/tests/DNS-Benchmark.Tests.ps1
+++ b/tests/DNS-Benchmark.Tests.ps1
@@ -358,6 +358,19 @@ Describe "Backup-DnsSettings" {
         $content.PreviousDNS | Should -Be "1.1.1.1"
     }
 
+    It "Should record the previous IPv6 servers when supplied (#8)" {
+        $path = Backup-DnsSettings -BackupDir $testDir -AdapterName "Wi-Fi" -InterfaceIndex 7 `
+            -CurrentDns @("1.1.1.1", "1.0.0.1") -CurrentDnsV6 @("2606:4700:4700::1111", "2606:4700:4700::1001")
+        $content = Get-Content $path -Raw | ConvertFrom-Json
+        $content.PreviousDNSv6 | Should -Be "2606:4700:4700::1111,2606:4700:4700::1001"
+    }
+
+    It "Should leave the IPv6 field empty when no IPv6 servers are given" {
+        $path = Backup-DnsSettings -BackupDir $testDir -AdapterName "Wi-Fi" -InterfaceIndex 7 -CurrentDns @("1.1.1.1")
+        $content = Get-Content $path -Raw | ConvertFrom-Json
+        $content.PreviousDNSv6 | Should -Be ""
+    }
+
     It "Should include an ISO 8601 timestamp" {
         $path = Backup-DnsSettings -BackupDir $testDir -AdapterName "Wi-Fi" -InterfaceIndex 1 -CurrentDns @("9.9.9.9")
         $raw = Get-Content $path -Raw
@@ -483,6 +496,127 @@ Describe "Set-OptimalDns" {
 
         $result = Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1"
         $result | Should -Be $true
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Set-OptimalDns - IPv6 path (#8)
+# ---------------------------------------------------------------------------
+Describe "Set-OptimalDns (IPv6)" {
+    BeforeEach {
+        Mock Set-DnsClientServerAddress { }
+        Mock Clear-DnsClientCache { }
+        Mock Get-DnsClientServerAddress {
+            [PSCustomObject]@{ ServerAddresses = @("1.1.1.1", "1.0.0.1") }
+        } -ParameterFilter { $AddressFamily -eq "IPv4" }
+    }
+
+    It "Should return `$true when both IPv4 and IPv6 families apply correctly" {
+        Mock Get-DnsClientServerAddress {
+            [PSCustomObject]@{ ServerAddresses = @("2606:4700:4700::1111", "2606:4700:4700::1001") }
+        } -ParameterFilter { $AddressFamily -eq "IPv6" }
+
+        $result = Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1" `
+            -PrimaryDnsV6 "2606:4700:4700::1111" -SecondaryDnsV6 "2606:4700:4700::1001"
+        $result | Should -Be $true
+    }
+
+    It "Should pass all four addresses to Set-DnsClientServerAddress in one call" {
+        Mock Get-DnsClientServerAddress {
+            [PSCustomObject]@{ ServerAddresses = @("2606:4700:4700::1111", "2606:4700:4700::1001") }
+        } -ParameterFilter { $AddressFamily -eq "IPv6" }
+
+        Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1" `
+            -PrimaryDnsV6 "2606:4700:4700::1111" -SecondaryDnsV6 "2606:4700:4700::1001" | Out-Null
+
+        Should -Invoke Set-DnsClientServerAddress -Times 1 -Exactly -ParameterFilter {
+            $ServerAddresses.Count -eq 4 -and
+            $ServerAddresses -contains "2606:4700:4700::1111" -and
+            $ServerAddresses -contains "1.1.1.1"
+        }
+    }
+
+    It "Should return `$false when the IPv6 family does not take" {
+        Mock Get-DnsClientServerAddress {
+            [PSCustomObject]@{ ServerAddresses = @() }
+        } -ParameterFilter { $AddressFamily -eq "IPv6" }
+
+        $result = Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1" `
+            -PrimaryDnsV6 "2606:4700:4700::1111" -SecondaryDnsV6 "2606:4700:4700::1001"
+        $result | Should -Be $false
+    }
+
+    It "Should ignore IPv6 and stay IPv4-only when only one v6 address is given" {
+        # No IPv6 read should happen; if the function tried, this mock would make it fail.
+        Mock Get-DnsClientServerAddress { throw "IPv6 read should not be reached" } -ParameterFilter { $AddressFamily -eq "IPv6" }
+
+        $result = Set-OptimalDns -InterfaceIndex 5 -PrimaryDns "1.1.1.1" -SecondaryDns "1.0.0.1" `
+            -PrimaryDnsV6 "2606:4700:4700::1111"
+        $result | Should -Be $true
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test-IPv6Available (#8)
+# ---------------------------------------------------------------------------
+Describe "Test-IPv6Available" {
+    It "Should return `$true when ms_tcpip6 is bound and enabled" {
+        Mock Get-NetAdapterBinding { [PSCustomObject]@{ ComponentID = "ms_tcpip6"; Enabled = $true } }
+        Test-IPv6Available -AdapterName "Wi-Fi" | Should -Be $true
+    }
+
+    It "Should return `$false when ms_tcpip6 is bound but disabled" {
+        Mock Get-NetAdapterBinding { [PSCustomObject]@{ ComponentID = "ms_tcpip6"; Enabled = $false } }
+        Test-IPv6Available -AdapterName "Wi-Fi" | Should -Be $false
+    }
+
+    It "Should fail-safe to `$false when the binding cannot be read" {
+        Mock Get-NetAdapterBinding { throw "adapter not found" }
+        Test-IPv6Available -AdapterName "Ghost" | Should -Be $false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# IPv6 resolver data (#8)
+# ---------------------------------------------------------------------------
+Describe "IPv6 resolver data" {
+    BeforeAll {
+        $dataScriptPath = Join-Path (Join-Path $PSScriptRoot "..") "DNS-Benchmark.ps1"
+        $dataContent = Get-Content $dataScriptPath -Raw
+        $dataAst = [System.Management.Automation.Language.Parser]::ParseInput($dataContent, [ref]$null, [ref]$null)
+        $assign = $dataAst.FindAll({
+            $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $args[0].Left.Extent.Text -eq '$DnsServers'
+        }, $true) | Select-Object -First 1
+        $script:DnsServers = Invoke-Expression $assign.Right.Extent.Text
+    }
+
+    It "Should define a non-empty resolver table" {
+        $script:DnsServers.Count | Should -BeGreaterThan 0
+    }
+
+    It "Should pair every IPv6 primary with an IPv6 secondary" {
+        foreach ($s in $script:DnsServers) {
+            $hasPrimary   = -not [string]::IsNullOrWhiteSpace($s.PrimaryV6)
+            $hasSecondary = -not [string]::IsNullOrWhiteSpace($s.SecondaryV6)
+            $hasPrimary | Should -Be $hasSecondary -Because "$($s.Name) must list both IPv6 addresses or neither"
+        }
+    }
+
+    It "Should only use real IPv6 literals for the v6 addresses" {
+        foreach ($s in $script:DnsServers) {
+            if (-not [string]::IsNullOrWhiteSpace($s.PrimaryV6)) {
+                ([System.Net.IPAddress]::Parse($s.PrimaryV6)).AddressFamily |
+                    Should -Be ([System.Net.Sockets.AddressFamily]::InterNetworkV6) -Because "$($s.Name) PrimaryV6"
+                ([System.Net.IPAddress]::Parse($s.SecondaryV6)).AddressFamily |
+                    Should -Be ([System.Net.Sockets.AddressFamily]::InterNetworkV6) -Because "$($s.Name) SecondaryV6"
+            }
+        }
+    }
+
+    It "Should carry IPv6 for the headline resolvers" {
+        ($script:DnsServers | Where-Object { $_.Name -eq "Cloudflare" }).PrimaryV6 | Should -Be "2606:4700:4700::1111"
+        ($script:DnsServers | Where-Object { $_.Name -eq "Google" }).PrimaryV6     | Should -Be "2001:4860:4860::8888"
     }
 }
 


### PR DESCRIPTION
Closes #8.

The benchmark only ever set IPv4 DNS. On a dual-stack network that leaves a
real gap: the machine can keep resolving over whatever IPv6 DNS the router
handed out and bypass the resolver the tool just picked.

## What changed
- Most providers in the table now carry their published IPv6 anycast
  addresses (Cloudflare, Google, Quad9, OpenDNS, AdGuard, CleanBrowsing,
  Mullvad, Control D). The few without stable public IPv6 stay IPv4-only.
- New `-IncludeIPv6` switch. When set, the winner's IPv6 addresses are
  applied alongside IPv4, but only if the adapter has IPv6 bound and the
  winner actually has v6 on file. Otherwise it falls back to IPv4 and says
  why.
- `Set-OptimalDns` sends both pairs in one call and verifies the IPv6
  family too, so a half-applied change reads as a failure.
- `Backup-DnsSettings` records the previous IPv6 servers, so a restore is
  complete.
- New `Test-IPv6Available` helper checks the ms_tcpip6 binding, fail-safe
  to off like the other guards.
- Off by default, so no IPv6 config changes unless asked for.

## Tests
- 13 new Pester cases: the IPv6 apply path (apply, verify-fail, one-address
  guard), `Test-IPv6Available` (bound, disabled, throws), the IPv6 backup
  field, and a parsed-from-source check that every v6 entry is a real,
  paired IPv6 literal so a typo gets caught here instead of on an adapter.
- Full suite 71/71 green, PSScriptAnalyzer clean. `checksums.txt` refreshed
  in the same commit as the script edit so the integrity test stays green.

## Follow-ups
- #12 (parallel benchmarking) is still open.
- Latency is still measured over IPv4 only. This sets IPv6 DNS but does not
  yet score resolvers on their IPv6 path. Could be a later pass.
